### PR TITLE
fix: Move resource.Id fields in the test definition

### DIFF
--- a/tests/album_object_test.yaml
+++ b/tests/album_object_test.yaml
@@ -3,26 +3,26 @@ name: AlbumObjectTestSuite
 description: Tests for verifying the album:object resource policy
 resources:
   alicia_private_album:
+    id: "XX666"
     kind: "album:object"
     attr:
       owner: "alicia"
-      id: "XX125"
       public: false
       flagged: false
 
   alicia_public_album:
+    id: "XX666"
     kind: "album:object"
     attr:
       owner: "alicia"
-      id: "XX525"
       public: true
       flagged: false
 
   alicia_flagged_album:
+    id: "XX666"
     kind: "album:object"
     attr:
       owner: "alicia"
-      id: "XX666"
       public: true
       flagged: true
 


### PR DESCRIPTION
Signed-off-by: Oğuzhan Durgun <oguzhandurgun95@gmail.com>

#### Description

In the tests, the `id` fields are under the `attr` fields. They should be under the root of each `resource`.

Caught it thanks to [#724](https://github.com/cerbos/cerbos/pull/724)